### PR TITLE
Get model info

### DIFF
--- a/Spark.Console/Commands/Pages/CreatePagesCommand.cs
+++ b/Spark.Console/Commands/Pages/CreatePagesCommand.cs
@@ -5,17 +5,21 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using static System.Runtime.InteropServices.JavaScript.JSType;
+
 
 namespace Spark.Console.Commands.Pages;
 
 public class CreatePagesCommand
 {
     private readonly static string PagePath = $"./Pages";
-
+    private readonly static string ModelPath = $"./Application/Models";
     public void Execute(string modelName)
     {
         string appName = UserApp.GetAppName();
+        // Get the class name and properties from the model
+        ModelInfo modelInfo = ModelExtractor.ExtractModelInfo($"{ModelPath}/{modelName}.cs");
 
         ConsoleOutput.GenerateAlert(new List<string>() { $"Creating pages for {modelName}" });
 

--- a/Spark.Console/Shared/ModelExtractor.cs
+++ b/Spark.Console/Shared/ModelExtractor.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Spark.Console.Shared
+{
+    public class ModelExtractor
+    {
+        public static ModelInfo ExtractModelInfo(string pathToFile)
+        {
+            ModelInfo modelInfo = new ModelInfo();
+            modelInfo.Name = ExtractClassName(pathToFile);
+            modelInfo.Path = pathToFile;
+            modelInfo.FileName = Path.GetFileName(pathToFile);
+            modelInfo.Properties = ExtractProperties(pathToFile);
+
+            return modelInfo;
+        }
+
+        public static string ExtractClassName(string pathToFile)
+        {
+            var code = File.ReadAllText(pathToFile);
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var root = syntaxTree.GetRoot();
+
+            var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+            if (classDeclaration != null)
+            {
+                return classDeclaration.Identifier.ValueText;
+            }
+
+            return "";
+        }
+
+        private static List<ModelProperty> ExtractProperties(string pathToFile)
+        {
+            List<ModelProperty> modelProperties = new List<ModelProperty>();
+            var code = File.ReadAllText(pathToFile);
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var root = syntaxTree.GetRoot();
+
+            foreach (var property in root.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+            {
+                ModelProperty mp = new ModelProperty()
+                {
+                    Name = property.Identifier.ValueText,
+                    Type = property.Type.ToString(),
+                    Accessors = property.AccessorList.ToString(),
+                    Modifiers = property.Modifiers.ToString()
+                };
+
+                modelProperties.Add(mp);
+            }
+            return modelProperties;
+        }
+    }
+
+    public class ModelInfo
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Path { get; set; } = string.Empty;
+        public string FileName { get; set; } = string.Empty;
+        public List<ModelProperty> Properties { get; set; }
+    }
+
+    public class ModelProperty
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public string Accessors { get; set; }
+        public string Modifiers { get; set; }
+    }
+}

--- a/Spark.Console/Spark.Console.csproj
+++ b/Spark.Console/Spark.Console.csproj
@@ -28,6 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added a file called ModelExtractor.cs in the Shared folder. The ModelExtractor.cs can read a .cs file and fint class name and properties. This file use the Nuget packages: Microsoft.CodeAnalysis and Microsoft.CodeAnalysis.CSharp.

In the CreatePagesCommand.cs file I added a line that show how to get the model inforamtion from a model.

Just for information: I have not contributed on open source projects before, so if I do anything wrong just let me no and I'll try to do it as you would like. :)

If it works to use this code in the CLI, it will be possible to make quite large and advanced templates for CRUD pages. Might be a good idea to add a template system like https://github.com/scriban/scriban or similar. If the page template files is stored in the the dotnet templates it will be possible to create a new Spark.NET project, edit the template files in that project and have consistent design for all the pages in that project. 