### PR TITLE
Fix Login method return in AuthController

### DIFF
--- a/Spark.Templates/working/templates/Spark.Templates.Api/Application/Controllers/AuthController.cs
+++ b/Spark.Templates/working/templates/Spark.Templates.Api/Application/Controllers/AuthController.cs
@@ -40,7 +40,7 @@ namespace Spark.Templates.Api.Application.Controllers
             if (user == null)
             {
                 ModelState.AddModelError("FailedLogin", "Login Failed: Your email or password was incorrect");
-                return View();
+                return BadRequest(ModelState);
             }
             
             var token = await _authService.CreateJwtToken(user);


### PR DESCRIPTION
* Fix the AuthController Login method's return in Spark.Templates.Api. It was incorrectly returning a View(); changed it to return a BadRequest with the ModelState.

Minor change but I hope it helps. :)