### PR TITLE
Return 404 status code

### DIFF
--- a/Spark.Templates/working/templates/Spark.Templates.Blazor/Pages/Errors/404.razor
+++ b/Spark.Templates/working/templates/Spark.Templates.Blazor/Pages/Errors/404.razor
@@ -14,3 +14,13 @@
 		</div>
 	</article>
 </section>
+
+@code
+{
+	[CascadingParameter] HttpContext HttpContext { get; set; } = default!;
+
+	protected override void OnInitialized()
+	{
+		HttpContext.Response.StatusCode = 404;
+	}
+}


### PR DESCRIPTION
The 404 page currently responds with a 200 status code which is semantically incorrect and bad for SEO

This PR returns the correct 404 code.